### PR TITLE
Support URIBLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const {Resolver} = require("dns");
 const ipPtr = require("ip-ptr");
 const {promisify} = require("util");
 const pMap = require("p-map");
+const ipAddr = require("ipaddr.js");
 
 const defaults = {
   timeout: 5000,
@@ -15,7 +16,7 @@ const defaults = {
 async function query(addr, blacklist, resolver, opts = {}) {
   const resolve4 = promisify(resolver.resolve4.bind(resolver));
   const resolveTxt = promisify(resolver.resolveTxt.bind(resolver));
-  const name = ipPtr(addr).replace(/\.i.+/, "") + "." + blacklist;
+  const name = (ipAddr.isValid(addr) ? ipPtr(addr).replace(/\.i.+/, "") : addr) + "." + blacklist;
 
   const timeout = setTimeout(() => {
     resolver.cancel();

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   ],
   "dependencies": {
     "ip-ptr": "^3.0.0",
+    "ipaddr.js": "^1.9.1",
     "p-map": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #10 

Code I used for dev purposes: https://gist.github.com/theel0ja/28f9b2c6fbe3d6d5fc4547680b211fcc

`includeTxt` is broken, though.

I guess it's this:
https://github.com/silverwind/dnsbl/blob/5c340a54e89702c40cb067710003ca62cd64e6dd/index.js#L35-L37

It returns "false" even if the A record is returned, if no TXT record exists on the URIBL 